### PR TITLE
Fix for issue #6

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <author>
         <name>Anthony Chevrier / Franck Allimant</name>
         <email>anthony@meedle.fr / thelia@cqfdev.fr</email>

--- a/Listener/ControllerListener.php
+++ b/Listener/ControllerListener.php
@@ -27,9 +27,13 @@ class ControllerListener implements EventSubscriberInterface
 
         $request = $event->getRequest();
 
+        $currentView = $event->getRequest()->attributes->get('_view');
+
         // Try to find a direct match. A view is defined for the object.
         foreach ($possibleMatches as $parameter => $objectType) {
-            if (null !== $objectId = $request->query->get($parameter)) {
+            // Search for a view when the parameter is present in the request, and
+            // the current view is the default one (fix for https://github.com/AnthonyMeedle/thelia-modules-View/issues/6)
+            if ($currentView == $objectType && (null !== $objectId = $request->query->get($parameter))) {
                 $findEvent = new FindViewEvent($objectId, $objectType);
 
                 $event->getDispatcher()->dispatch('view.find', $findEvent);


### PR DESCRIPTION
The view is changed only if the current view (found in the `_view` attribute) is the default one. For example if the `product_id` parameter is present in the request, we will try to change the view only if the current view is set to 'product'.