### PR TITLE
Prevent walking in bower and node_modules directories

### DIFF
--- a/Loop/Frontfiles.php
+++ b/Loop/Frontfiles.php
@@ -68,9 +68,8 @@ class Frontfiles extends BaseLoop implements ArraySearchLoopInterface
         $finder = Finder::create()
             ->files()
             ->in($frontTemplatePath)
-            // Ignore bower and node directories
-            ->notPath('/bower_components/')
-            ->notPath('/node_modules/')
+            // Do not enter in bower and node directories
+            ->exclude(['bower_components', 'node_modules'])
             // Ignore VCS related directories
             ->ignoreVCS(true)
             ->ignoreDotFiles(true)


### PR DESCRIPTION
Prevent the Frontfiles loop to enter `bower_components `and `node_modules `directories, which may contains a LOT of files and subdirectories, which may significantly slow display of product, categories, folder and contents pages in the back-office.